### PR TITLE
Fix benchmark tests to enable successful automated releases

### DIFF
--- a/benchmark_suite_test.go
+++ b/benchmark_suite_test.go
@@ -80,7 +80,7 @@ func benchmarkStartupTime(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		start := time.Now()
 		
-		cmd := exec.Command("./goclean", "--help")
+		cmd := exec.Command("./bin/goclean", "--help")
 		cmd.Dir = "."
 		err := cmd.Run()
 		if err != nil {
@@ -126,7 +126,7 @@ func TestFunction%d() {
 	for i := 0; i < b.N; i++ {
 		start := time.Now()
 		
-		cmd := exec.Command("./goclean", "scan", "--path", testDir, "--output-format", "console")
+		cmd := exec.Command("./bin/goclean", "scan", testDir)
 		cmd.Dir = "."
 		err := cmd.Run()
 		if err != nil {
@@ -163,7 +163,7 @@ func benchmarkMemoryUsage(b *testing.B) {
 	b.ReportAllocs()
 	
 	for i := 0; i < b.N; i++ {
-		cmd := exec.Command("./goclean", "scan", "--path", testDir, "--output-format", "console")
+		cmd := exec.Command("./bin/goclean", "scan", testDir)
 		cmd.Dir = "."
 		err := cmd.Run()
 		if err != nil {
@@ -193,8 +193,8 @@ func benchmarkReportGeneration(b *testing.B) {
 		start := time.Now()
 		
 		outputPath := fmt.Sprintf("%s/report-%d.html", b.TempDir(), i)
-		cmd := exec.Command("./goclean", "scan", "--path", testDir, 
-			"--output-format", "html", "--output-path", outputPath)
+		cmd := exec.Command("./bin/goclean", "scan", testDir, 
+			"--format", "html", "--output", outputPath)
 		cmd.Dir = "."
 		err := cmd.Run()
 		if err != nil {


### PR DESCRIPTION
## Summary
Fixes the benchmark validation step that was causing the automated release workflow to fail.

## Issues Fixed
The `make benchmark-validate` step in the release workflow was failing due to:

1. **Incorrect CLI arguments** - Using deprecated `--path` flag instead of positional arguments
2. **Wrong output format flag** - Using `--output-format` instead of `--format` 
3. **Incorrect binary paths** - Looking for `./goclean` instead of `./bin/goclean`
4. **Wrong output flag** - Using `--output-path` instead of `--output`

## Changes Made
- ✅ Updated all benchmark CLI commands to use correct syntax
- ✅ Fixed binary paths to point to `./bin/goclean` 
- ✅ Replaced deprecated flags with current CLI interface
- ✅ Verified all benchmarks now pass locally

## Testing
```bash
make benchmark-validate
```
All benchmarks now pass successfully:
- ✅ StartupTime
- ✅ ScanningSpeed  
- ✅ MemoryUsage
- ✅ ReportGeneration

## Impact
This should resolve the release workflow failure and enable successful automated releases. The previous v0.2.1 release attempt failed at the benchmark step, but with these fixes, the full release workflow should complete successfully.

## Related
- Builds on previous HTML reporter fixes from PR #29
- Completes the automated release pipeline fixes