### PR TITLE
Debug GitHub Actions benchmark failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ LDFLAGS = -ldflags "-X main.Version=$(VERSION) -X main.GitCommit=$(GIT_COMMIT) -
 # Build the application
 build:
 	@echo "Building $(BINARY_NAME) $(VERSION)..."
+	@echo "Working directory: $(PWD)"
+	@echo "Main path: $(MAIN_PATH)"
+	@ls -la $(MAIN_PATH) 2>/dev/null || echo "Directory $(MAIN_PATH) not found, listing current dir:" && ls -la .
 	@mkdir -p $(BUILD_DIR)
 	$(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) $(MAIN_PATH)
 


### PR DESCRIPTION
## Summary
Add debugging output to Makefile to diagnose why the GitHub Actions release workflow fails at the benchmark step.

## Issue
The release workflow fails with:
```
stat /home/runner/work/GoClean/GoClean/cmd/goclean: directory not found
make: *** [Makefile:30: build] Error 1
```

## Debugging Added
- Print working directory in build target
- Print main path being used
- List directory contents when path is not found
- This will help understand the GitHub Actions environment structure

## Next Steps
Once merged, we can recreate the v0.2.1 tag to trigger the workflow and see the debug output to understand why the `./cmd/goclean` directory is not found in GitHub Actions but works locally.

## Note
This is temporary debugging that can be removed once we identify and fix the root cause.